### PR TITLE
Add a line break to make separate paragraphs

### DIFF
--- a/grunt.util.md
+++ b/grunt.util.md
@@ -148,6 +148,7 @@ use it in your `Gruntfile`: `var _ = require('lodash');`
 
 #### grunt.util._
 *Deprecated*
+
 [Lo-Dash](http://lodash.com/) and [Underscore.string](https://github.com/epeli/underscore.string)
 
 `grunt.util._.str` is available for methods that conflict with existing Lo-Dash methods.


### PR DESCRIPTION
At present, the position of "_Deprecated_" statement in the `grunt.util._` section seems to be different from `grunt.util.async` and `grunt.util.hooker`'s.

I think "_Deprecated_" should be in another paragraph separated from the next sentence "Lo-dash and ...".

Here is the screenshot of http://gruntjs.com/api/grunt.util#external-libraries:

![screenshot-2013-12-16-2 47 21](https://f.cloud.github.com/assets/1131567/1750764/e2b3296c-65b1-11e3-8b8b-37dd73f680af.jpg)
