### PR TITLE
Handling Large Scale projects article

### DIFF
--- a/Multiple-Gruntfiles.md
+++ b/Multiple-Gruntfiles.md
@@ -247,10 +247,12 @@ module.exports = function(grunt) {
 
 So, bottom line, to properly extend your custom tasks [`grunt.task.loadTasks`](http://gruntjs.com/api/grunt.task#grunt.task.loadtasks) is your friend.
 
+This article was authored by [thanpolas][].
+
 [Handling Frontend Dependencies]: #handling-frontend-dependencies
 [extconf]: #extending-grunts-configuration
 [exttask]: #extending-grunts-custom-tasks
 [grunt.config]: http://gruntjs.com/api/grunt.config
 [Ben Alman]: https://github.com/cowboy
 [wesbos repo]: https://github.com/cowboy/wesbos
-
+[thanpolas]: https://githug.com/thanpolas


### PR DESCRIPTION
Time and again i see users falling into the fallacy of having multiple `Gruntfile.js` files in their projects and asking questions about how to run tasks for them...

This article tries to provide a path into scaling Grunt for large teams, it is designed to exist under the `Documentation --> Advanced --> Multiple Gruntfiles` pos in the gruntjs site, the title although deceiving, is what will attract the target audience's attention and provide useful SEO for the issue.

I'll make it a blog post if you don't want the piece.
