### PR TITLE
Adds documentation for extDot

### DIFF
--- a/Configuring-tasks.md
+++ b/Configuring-tasks.md
@@ -243,6 +243,7 @@ When you want to process many individual files, a few additional properties may 
 * `src` Pattern(s) to match, relative to the `cwd`.
 * `dest` Destination path prefix.
 * `ext` Replace any existing extension with this value in generated `dest` paths.
+* `extDot` Used to indicate where the period indicating the extension is located. Can take either `'first'` (extension begins after the first period in the file name) or `'last'` (extension begins after the last period), and is set by default to `'first'`.
 * `flatten` Remove all path parts from generated `dest` paths.
 * `rename` This function is called for each matched `src` file, (after extension renaming and flattening). The `dest`
 and matched `src` path are passed in, and this function must return a new `dest` value.  If the same `dest` is returned
@@ -276,6 +277,7 @@ grunt.initConfig({
           src: ['**/*.js'], // Actual pattern(s) to match.
           dest: 'build/',   // Destination path prefix.
           ext: '.min.js',   // Dest filepaths will have this extension.
+          extDot: 'first'   // Extensions in filenames begin after the first dot
         },
       ],
     },

--- a/grunt.file.md
+++ b/grunt.file.md
@@ -196,9 +196,15 @@ var options = {
   // Remove the path component from all matched src files. The src file path
   // is still joined to the specified dest.
   flatten: Boolean,
-  // Remove anything after (and including) the first "." in the destination
-  // path, then append this value.
+  // Remove anything after (and including) either the first or last "." in the 
+  // destination path (indicated by options.extDot), then append this value.
   ext: String,
+  // *Added in 0.4.3*
+  // Indicates where the period demarcating the extension is located. Can take:
+  // - 'first' (extension begins after the first period in the file name) 
+  // - 'last' (extension begins after the last period)
+  // Default: 'first'
+  extDot: String,
   // If specified, this function will be responsible for returning the final
   // dest filepath. By default, it joins dest and matchedSrcPath like so:
   rename: function(dest, matchedSrcPath, options) {


### PR DESCRIPTION
This pull request adds documentation for the `extDot` option introduced in https://github.com/gruntjs/grunt/issues/979 and added to v0.4.3. I believe this covers all the places in the docs where `ext` was located.
