### PR TITLE
Remove BitDeli badge

### DIFF
--- a/Built-with-Grunt-Badge.md
+++ b/Built-with-Grunt-Badge.md
@@ -20,7 +20,6 @@ If you need an HTML version, we've got you covered.
 
 As you can see, the "Built with Grunt" badge is modern, stylish, and has been designed to fit nicely next to all your project's other mini-badges. You can put it first, last, or anywhere in the middle. Have fun!
 
-[![BitDeli](https://d2weczhvl823v0.cloudfront.net/bitdeli/bitdeli-tracking-js/trend.png)](https://bitdeli.com/)
 [![NPM version](https://badge.fury.io/js/grunt.png)](http://badge.fury.io/)
 [![Coverage Status](https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_100.png)](https://coveralls.io/)
 [![Build Status](https://secure.travis-ci.org/gruntjs/grunt.png?branch=master)](http://travis-ci.org/)


### PR DESCRIPTION
BitDeli is essentially dead due to a GitHub update in January. Relevant articles:
http://blog.bitdeli.com/post/77717727361/on-githubs-image-proxy
https://github.com/blog/1672-introducing-github-traffic-analytics
