### PR TITLE
Examples and wording in templating

### DIFF
--- a/grunt.template.md
+++ b/grunt.template.md
@@ -3,7 +3,7 @@ Template strings can be processed manually using the provided template functions
 ### grunt.template.process
 Process a [Lo-Dash template](http://lodash.com/docs/#template) string. The `template` argument will be processed recursively until there are no more templates to process.
 
-The default data object is the entire config object, but if `options.data` is set, that object will be used instead. The default template delimiters are `<% %>` but if `options.delimiters` is set to a custom delimiter name, those template delimiters will be used instead.
+The default data object is the entire config object, but if `options.data` is set, that object will be used instead. The default template delimiters are `<% %>` but if `options.delimiters` is set to a custom delimiter name (set with [`grunt.template.addDelimiters`](#grunt.template.adddelimiters)), those template delimiters will be used instead.
 
 ```js
 grunt.template.process(template [, options])
@@ -23,7 +23,7 @@ grunt.template.process('<%= baz %>', {data: obj}) // 'abcde'
 ```
 
 ### grunt.template.setDelimiters
-Set the [Lo-Dash template](http://lodash.com/docs/#template) delimiters to a predefined set in case you `grunt.util._.template` needs to be called manually. The `config` delimiters `<% %>` are included by default.
+Set the [Lo-Dash template](http://lodash.com/docs/#template) delimiters to a predefined set in case `grunt.util._.template` needs to be called manually. The `config` delimiters `<% %>` are included by default.
  
 _You probably won't need to use this method, because you'll be using `grunt.template.process` which uses this method internally._
 
@@ -34,8 +34,16 @@ grunt.template.setDelimiters(name)
 ### grunt.template.addDelimiters
 Add a named set of [Lo-Dash template](http://lodash.com/docs/#template) delimiters. You probably won't need to use this method, because the built-in delimiters should be sufficient, but you could always add `{% %}` or `[% %]` style delimiters.
 
+The `name` argument should be unique since it is how we access the delimiters from `grunt.template.setDelimiters` and as an option for `grunt.template.process`.
+
 ```js
 grunt.template.addDelimiters(name, opener, closer)
+```
+
+In this example, if we were to use the `{% %}` style mentioned above we would use the following:
+
+```js
+grunt.template.addDelimiters('myDelimiters', '{%', '%}')
 ```
 
 ## Helpers


### PR DESCRIPTION
- There's some magic that goes into making the regex for delimiters so an example is worthy.
- Mentioned where and how to use the name for custom delimiters.
- Dropped a confusing 'you' that was probably left by accident.
