### PR TITLE
fix grunt.fail.md on method name

### DIFF
--- a/grunt.fail.md
+++ b/grunt.fail.md
@@ -8,7 +8,7 @@ If something explodes (or is about to explode) inside a task, it can force Grunt
 
 Note that any method marked with a ☃ (unicode snowman) is also available directly on the `grunt` object. Just so you know. See the [API main page](grunt) for more usage information.
 
-### grunt.warn ☃
+### grunt.fail.warn ☃
 Display a warning and abort Grunt immediately. Grunt will continue processing tasks if the `--force` command-line option was specified. The `error` argument can be a string message or an error object.
 
 ```javascript
@@ -19,7 +19,7 @@ If `--stack` is specified on the command-line and an error object was specified,
 
 _This method is also available as `grunt.warn`._
 
-### grunt.fatal ☃
+### grunt.fail.fatal ☃
 Display a warning and abort Grunt immediately. The `error` argument can be a string message or an error object.
 
 ```javascript


### PR DESCRIPTION
This file is for grunt.fail, so use `grunt.fail.warn` and `grunt.fail.fatal` may be better than `grunt.warn` and `grunt.fatal`. And we can see the alias is `grunt.warn` and `grunt.fatal` some lines below.
