### PR TITLE
fix arguments format

### DIFF
--- a/grunt.util.md
+++ b/grunt.util.md
@@ -47,7 +47,7 @@ grunt.util.pluralize(n, str, separator)
 ```
 
 ### grunt.util.spawn
-Spawn a child process, keeping track of its stdout, stderr and exit code. The method returns a reference to the spawned child. When the child exits, the done function is called.
+Spawn a child process, keeping track of its stdout, stderr and exit code. The method returns a reference to the spawned child. When the child exits, the `doneFunction` is called.
 
 ```js
 grunt.util.spawn(options, doneFunction)
@@ -73,7 +73,7 @@ var options = {
 };
 ```
 
-The done function accepts these arguments:
+The `doneFunction` accepts these arguments:
 
 ```js
 function doneFunction(error, result, code) {


### PR DESCRIPTION
"doneFunction" is an argument in `grunt.util.spawn` function, and according to the situation above(I extracted them bolew), "`doneFunction`" may be better than "done function".

> ### grunt.util.repeat
> 
> Return string `str` repeated `n` times.
> ### grunt.util.pluralize
> 
> Given `str` of `"a/b"`, If `n` is `1`, return `"a"` otherwise `"b"`. You can specify a custom separator if '/' doesn't work for you.
