### PR TITLE
Update Who-uses-Grunt.md

### DIFF
--- a/Who-uses-Grunt.md
+++ b/Who-uses-Grunt.md
@@ -2,6 +2,8 @@ This is just a short list of companies and projects that use Grunt.
 If you've used Grunt in a project and would like it listed on this page,
 [please edit this page](https://github.com/gruntjs/grunt-docs/blob/master/Who-uses-Grunt.md).
 
+### [INK](http://ink.sapo.pt)
+
 ### [Adobe](http://www.adobe.com/)
 - [Brackets](http://brackets.io/) ([Gruntfile](https://github.com/adobe/brackets/blob/master/Gruntfile.js))
 - [CSS FilterLab](http://html.adobe.com/webstandards/csscustomfilters/cssfilterlab/) ([Gruntfile](https://github.com/adobe/cssfilterlab/blob/master/grunt.js))


### PR DESCRIPTION
Adds [INK](http://ink.sapo.pt) framework to  Who-uses-Grunt.md
