### PR TITLE
WordPress.ORG, not .com

### DIFF
--- a/Who-uses-Grunt.md
+++ b/Who-uses-Grunt.md
@@ -50,7 +50,7 @@ If you've used Grunt in a project and would like it listed on this page,
 ### [LiveChat](http://www.livechatinc.com)
 - [LiveChat Grunt Workflow](http://developers.livechatinc.com/blog/how-livechat-uses-grunt-js-for-easy-product-deployment/)
 
-### [WordPress](https://wordpress.com/)
+### [WordPress](https://wordpress.org/)
 - [WordPress Build Process](https://make.wordpress.org/core/2013/08/06/a-new-frontier-for-core-development/) ([Gruntfile](https://core.trac.wordpress.org/browser/trunk/Gruntfile.js))
 - [bbPress](https://bbpress.org) ([Gruntfile](https://bbpress.trac.wordpress.org/browser/trunk/Gruntfile.js))
 - [BuddyPress](https://buddypress.org) ([Gruntfile](https://buddypress.trac.wordpress.org/browser/trunk/Gruntfile.js))


### PR DESCRIPTION
It is wordpress.org that creates, makes, maintains the WordPress software.

WordPress.com via https://en.wikipedia.org/wiki/Wordpress.com

> WordPress.com is a blog web hosting service provider owned by Automattic, and powered by the open source WordPress software.

WordPress.org via https://en.wikipedia.org/wiki/WordPress

> On September 9, 2010, Automattic handed the WordPress trademark to the newly created WordPress Foundation, which is an umbrella organization supporting WordPress.org (including the software and archives for Plugins and Themes), bbPress and BuddyPress.

(Think of WordPress.com as similar to any other web hosting company except they only host WordPress powered sites)
