### PR TITLE
Update Creating-tasks.md

### DIFF
--- a/Creating-tasks.md
+++ b/Creating-tasks.md
@@ -26,7 +26,7 @@ When a multi task is run, Grunt looks for a property of the same name in the Gru
 
 Specifying both a task and target like `grunt concat:foo` or `grunt concat:bar` will process just the specified target's configuration, while running `grunt concat` will iterate over _all_ targets, processing each in turn.  Note that if a task has been renamed with [grunt.task.renameTask](grunt.task#grunt.task.renameTask), Grunt will look for a property with the _new_ task name in the config object.
 
-Most of the contrib tasks, including the [grunt-contrib-jshint plugin jshint task](https://github.com/gruntjs/grunt-contrib-jshint), [concat task](https://github.com/gruntjs/grunt-contrib-concat) and [grunt-contrib-concat plugin concat task](https://github.com/gruntjs/grunt-contrib-concat) are multi tasks.
+Most of the contrib tasks, including the [grunt-contrib-jshint plugin jshint task](https://github.com/gruntjs/grunt-contrib-jshint#jshint-task) and [grunt-contrib-concat plugin concat task](https://github.com/gruntjs/grunt-contrib-concat#concat-task) are multi tasks.
 
 ```javascript
 grunt.registerMultiTask(taskName, [description, ] taskFunction)


### PR DESCRIPTION
The grunt-contrib-concat plugin concat task was listed twice, also added anchor references to that and jshint task links.
