### PR TITLE
Fixed indentation on first example of grunt.option

### DIFF
--- a/grunt.option.md
+++ b/grunt.option.md
@@ -7,10 +7,10 @@ An example `Gruntfile` to utilize the `target` option could be:
 ```javascript
 grunt.initConfig({
   compass: {
-   dev: {
-     options: {
-       /* ... */
-       outputStyle: 'expanded'
+    dev: {
+      options: {
+        /* ... */
+        outputStyle: 'expanded'
       },
     },
     staging: {


### PR DESCRIPTION
Was reading through the docs and actually got confused because of this error on indentation.

This change only fixes the issue on the first example of grunt.option page.
