### PR TITLE
Replaced "npm remove" with "npm uninstall"

### DIFF
--- a/Frequently-Asked-Questions.md
+++ b/Frequently-Asked-Questions.md
@@ -90,7 +90,7 @@ Example: `grunt.registerTask('uglify', ['uglify:my_target']);` should be `grunt.
 
 ## How do I uninstall or remove unwanted plugins?
 
-At least two ways. One way is to use `npm remove [GRUNT_PLUGIN] --save-dev`, this will remove the plugin from your `package.json` and from `node_modules`. You may also delete the dependencies you don't want from your `package.json` manually and then run `npm prune`.
+At least two ways. One way is to use `npm uninstall [GRUNT_PLUGIN] --save-dev`, this will remove the plugin from your `package.json` and from `node_modules`. You may also delete the dependencies you don't want from your `package.json` manually and then run `npm prune`.
 
 ## Error "Fail to install with npm error: No compatible version found"
 


### PR DESCRIPTION
[FAQ page](http://gruntjs.com/frequently-asked-questions) tells to use `npm remove [GRUNT_PLUGIN] --save-dev` to uninstall unwanted plugins, while [correct command](https://www.npmjs.org/doc/cli/npm-uninstall.html) is `npm uninstall [GRUNT_PLUGIN] --save-dev`. While `npm remove` still work it is an alias.
