### PR TITLE
Fix two broken links

### DIFF
--- a/Getting-started.md
+++ b/Getting-started.md
@@ -3,7 +3,7 @@ Grunt 0.4.x requires stable Node.js versions `>= 0.8.0`. Odd version numbers of 
 
 Before setting up Grunt ensure that your [npm](https://npmjs.org/) is up-to-date by running `npm update -g npm` (this might require `sudo` on certain systems).
 
-If you already have installed Grunt and is now searching for some quick reference, please checkout our [`Gruntfile` example](/sample-gruntfile) and how to [configure a task](/configuring-tasks).
+If you already have installed Grunt and is now searching for some quick reference, please checkout our [`Gruntfile` example](http://gruntjs.com/sample-gruntfile) and how to [configure a task](http://gruntjs.com/configuring-tasks).
 
 ## Installing the CLI
 **Using Grunt 0.3? Please see [Grunt 0.3 Notes](upgrading-from-0.3-to-0.4#grunt-0.3-notes)**


### PR DESCRIPTION
Two links in the first section are broken on the page:
http://gruntjs.com/getting-started

I've fixed the links using full paths which follows the format of other links on the site.
