### PR TITLE
Update task use case

### DIFF
--- a/Creating-tasks.md
+++ b/Creating-tasks.md
@@ -112,8 +112,9 @@ grunt.registerTask('foo', 'My "foo" task.', function(a, b) {
 });
 
 // Usage:
-// grunt foo foo:bar
+// grunt foo
 //   logs: "foo", undefined, undefined
+// grunt foo foo:bar
 //   logs: "foo", "bar", undefined
 // grunt foo:bar:baz
 //   logs: "foo", "bar", "baz"


### PR DESCRIPTION
Under "Tasks can access their own name and arguments.", corrected commented logs to include `grunt foo` without arguments.