### PR TITLE
Fixed link "git URL as a dependency"

### DIFF
--- a/Installing-grunt.md
+++ b/Installing-grunt.md
@@ -23,6 +23,6 @@ _In this case it is **very important** that you manually edit your `package.json
 The same process may be used to install a published development version of a Grunt plugin.
 
 ## Installing directly from github
-If you want to install a bleeding-edge, unpublished version of Grunt or Grunt plugin, follow the instructions for specifying a [git URL as a dependency](https://npmjs.org/doc/json.html#Git-URLs-as-Dependencies) and be sure to specify an actual commit SHA (not a branch name) as the `commit-ish`. This will guarantee that your project always uses that exact version of grunt.
+If you want to install a bleeding-edge, unpublished version of Grunt or Grunt plugin, follow the instructions for specifying a [git URL as a dependency](https://docs.npmjs.com/files/package.json#git-urls-as-dependencies) and be sure to specify an actual commit SHA (not a branch name) as the `commit-ish`. This will guarantee that your project always uses that exact version of grunt.
 
 The specified git URL may be that of the official Grunt repo or a fork.


### PR DESCRIPTION
Fixed issue: link "git URL as a dependency" does not work #126