### PR TITLE
Updated "Built with Grunt" badge to the new standardised SVG version

### DIFF
--- a/Built-with-Grunt-Badge.md
+++ b/Built-with-Grunt-Badge.md
@@ -1,19 +1,19 @@
 Do you use Grunt in a project and want to proudly display that in your project README or on your project website? Now you can with the "Built with Grunt" badge!
 
-[![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com/)
+[![Built with Grunt](https://cdn.gruntjs.com/builtwith.svg)](http://gruntjs.com/)
 
 ## Using the Badge
 
 Just copy the following Markdown code snippet and paste it right underneath the headline in your project README. You can also put it on your project website homepage or footer.
 
 ```
-[![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com/)
+[![Built with Grunt](https://cdn.gruntjs.com/builtwith.svg)](http://gruntjs.com/)
 ```
 
 If you need an HTML version, we've got you covered.
 
 ```html
-<a href="http://gruntjs.com/"><img src="https://cdn.gruntjs.com/builtwith.png" alt="Built with Grunt"></a>
+<a href="http://gruntjs.com/"><img src="https://cdn.gruntjs.com/builtwith.svg" alt="Built with Grunt"></a>
 ```
 
 ## For example...
@@ -23,7 +23,7 @@ As you can see, the "Built with Grunt" badge is modern, stylish, and has been de
 [![NPM version](https://badge.fury.io/js/grunt.png)](http://badge.fury.io/)
 [![Coverage Status](https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_100.png)](https://coveralls.io/)
 [![Build Status](https://secure.travis-ci.org/gruntjs/grunt.png?branch=master)](http://travis-ci.org/)
-[![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com/)
+[![Built with Grunt](https://cdn.gruntjs.com/builtwith.svg)](http://gruntjs.com/)
 
 ## Shout-outs
 

--- a/Built-with-Grunt-Badge.md
+++ b/Built-with-Grunt-Badge.md
@@ -20,9 +20,9 @@ If you need an HTML version, we've got you covered.
 
 As you can see, the "Built with Grunt" badge is modern, stylish, and has been designed to fit nicely next to all your project's other mini-badges. You can put it first, last, or anywhere in the middle. Have fun!
 
-[![NPM version](https://badge.fury.io/js/grunt.png)](http://badge.fury.io/)
-[![Coverage Status](https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_100.png)](https://coveralls.io/)
-[![Build Status](https://secure.travis-ci.org/gruntjs/grunt.png?branch=master)](http://travis-ci.org/)
+[![NPM version](https://badge.fury.io/js/grunt.svg)](http://badge.fury.io/)
+[![Coverage Status](https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_100.svg)](https://coveralls.io/)
+[![Build Status](https://secure.travis-ci.org/gruntjs/grunt.svg?branch=master)](http://travis-ci.org/)
 [![Built with Grunt](https://cdn.gruntjs.com/builtwith.svg)](http://gruntjs.com/)
 
 ## Shout-outs


### PR DESCRIPTION
- Updated "Built with Grunt" badge to the new standardised SVG version
- Updated other badges to standardised SVG versions …
  - Important, because now they're all the same height
  - Makes the "Built with Grunt" badge look as uniform and professional as it should

Resolves [#165](https://github.com/gruntjs/gruntjs.com/issues/165)