### PR TITLE
Creating tasks: foo bar examples

### DIFF
--- a/Creating-tasks.md
+++ b/Creating-tasks.md
@@ -112,8 +112,9 @@ grunt.registerTask('foo', 'My "foo" task.', function(a, b) {
 });
 
 // Usage:
-// grunt foo foo:bar
+// grunt foo
 //   logs: "foo", undefined, undefined
+// grunt foo foo:bar
 //   logs: "foo", "bar", undefined
 // grunt foo:bar:baz
 //   logs: "foo", "bar", "baz"

--- a/Creating-tasks.md
+++ b/Creating-tasks.md
@@ -114,7 +114,7 @@ grunt.registerTask('foo', 'My "foo" task.', function(a, b) {
 // Usage:
 // grunt foo
 //   logs: "foo", undefined, undefined
-// grunt foo foo:bar
+// grunt foo:bar
 //   logs: "foo", "bar", undefined
 // grunt foo:bar:baz
 //   logs: "foo", "bar", "baz"

--- a/Creating-tasks.md
+++ b/Creating-tasks.md
@@ -169,6 +169,8 @@ grunt.registerTask('bar', 'My "bar" task.', function() {
 // Usage:
 // grunt foo bar
 //   doesn't log, because foo failed.
+//   ***Note: This is an example of space-separated sequential commands,
+//   (similar to executing two lines of code: `grunt foo` then `grunt bar`)
 // grunt bar
 //   doesn't log, because foo never ran.
 ```


### PR DESCRIPTION
* Separated `grunt foo foo:bar` into two lines of code, to make examples more readable:
  - `grunt foo`
  - `grunt foo:bar`
* Added comment explaining space-separated sequential commands
  * This is because sequential commands haven't been explained on this page, making the code less easily understood

Corrects issues in [PR#132](https://github.com/gruntjs/grunt-docs/pull/132).