### PR TITLE
Array for dynamic_mappings is incorrect

### DIFF
--- a/Configuring-tasks.md
+++ b/Configuring-tasks.md
@@ -316,16 +316,14 @@ grunt.initConfig({
       // Grunt will search for "**/*.js" under "lib/" when the "uglify" task
       // runs and build the appropriate src-dest file mappings then, so you
       // don't need to update the Gruntfile when files are added or removed.
-      files: [
-        {
-          expand: true,     // Enable dynamic expansion.
-          cwd: 'lib/',      // Src matches are relative to this path.
-          src: ['**/*.js'], // Actual pattern(s) to match.
-          dest: 'build/',   // Destination path prefix.
-          ext: '.min.js',   // Dest filepaths will have this extension.
-          extDot: 'first'   // Extensions in filenames begin after the first dot
-        },
-      ],
+      files: {
+        expand: true,     // Enable dynamic expansion.
+        cwd: 'lib/',      // Src matches are relative to this path.
+        src: ['**/*.js'], // Actual pattern(s) to match.
+        dest: 'build/',   // Destination path prefix.
+        ext: '.min.js',   // Dest filepaths will have this extension.
+        extDot: 'first'   // Extensions in filenames begin after the first dot
+      },
     },
   },
 });


### PR DESCRIPTION
When you use an array for files with a dynamic_mapping, the following warning appears and no files are found:

`Warning: pattern.indexOf is not a function Use --force to continue.`

Without the array the files properly expand.  
**Note: ** this could instead be a bug in grunt/task.js with how it looks at obj.extend on line 138.